### PR TITLE
fix deprecated selectors

### DIFF
--- a/index.less
+++ b/index.less
@@ -1,17 +1,17 @@
-.editor, .editor .gutter {
+atom-text-editor, :host, atom-text-editor .gutter, :host .gutter {
 	background-color: #0C1021;
 	color: #F8F8F8;
 }
 
-.editor.is-focused .cursor {
+atom-text-editor.is-focused .cursor, :host.is-focused .cursor {
 	border-color: rgba(255, 255, 255, 0.65);
 }
 
-.editor.is-focused .selection .region {
+atom-text-editor.is-focused .selection .region, :host.is-focused .selection .region {
 	background-color: #253B76;
 }
 
-.editor.is-focused .line-number.cursor-line-no-selection, .editor.is-focused .line.cursor-line {
+atom-text-editor.is-focused .line-number.cursor-line-no-selection, :host.is-focused .line-number.cursor-line-no-selection, atom-text-editor.is-focused .line.cursor-line, :host.is-focused .line.cursor-line {
 	background-color: rgba(255, 255, 255, 0.06);
 }
 


### PR DESCRIPTION
* Use the `atom-text-editor` tag instead of the `editor` class
* Target the selector `:host, atom-text-editor` instead of `.editor`
for shadow DOM support

_Deprecation Cop_
![bildschirmfoto 2015-04-02 um 15 37 52](https://cloud.githubusercontent.com/assets/464300/6964961/50fdf92c-d94e-11e4-8edd-0396bc51df9a.png)

https://atom.io/docs/v0.186.0/upgrading/upgrading-your-syntax-theme
https://atom.io/docs/v0.189.0/upgrading-to-1-0-apis-upgrading-your-syntax-theme

> fixes #2
> fixes #3